### PR TITLE
fix: assignee 설정되지 않도록 수정

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -2,7 +2,7 @@
 addReviewers: true
 
 # Set to true to add assignees to pull requests
-addAssignees: true
+addAssignees: false
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers: 


### PR DESCRIPTION
# What is this PR? 🔍
- **이슈** : 
- **관련 문서** :


# Changes 📝
auto-assign에서 Assignees에도 팀원들이 할당되는 이슈가 있어서 자동 할당 설정을 해제했습니다...🙃


# Screenshot 📸


# To Reviewers 🙏