### PR TITLE
fix: navigationbar 투명하게 해둔 것 막기

### DIFF
--- a/Features/MOITList/MOITListUserInterface/Implement/MOITListViewController.swift
+++ b/Features/MOITList/MOITListUserInterface/Implement/MOITListViewController.swift
@@ -164,10 +164,17 @@ final class MOITListViewController: UIViewController, MOITListPresentable, MOITL
                     .width(100%)
                     .backgroundColor(ResourceKitAsset.Color.gray100.color)
                     
+                flex.addItem()
+                    .backgroundColor(ResourceKitAsset.Color.gray100.color)
+                    .width(100%)
+                    .height(56)
+                    
                 flex.addItem(self.navigationBar)
+                    
+                    .backgroundColor(ResourceKitAsset.Color.gray100.color)
                     .height(56)
                     .width(100%)
-                    .marginTop(self.view.safeAreaInsets.top + 56)
+//                    .marginTop(self.view.safeAreaInsets.top)
             }
         
         self.scrollView.flex


### PR DESCRIPTION
# What is this PR? 🔍
- **이슈** : ❌ 
- **관련 문서** : ❌ 


# Changes 📝
- 네비바와 그 위의 safearea 투명 -> 배경색과 동일하게 수정


# Screenshot 📸

https://github.com/mash-up-kr/MOIT-iOS/assets/89574881/16319ff0-327a-452e-895c-791fe15d1979




# To Reviewers 🙏